### PR TITLE
refbox: changed logs location to relative location

### DIFF
--- a/compose_files/refbox.yaml
+++ b/compose_files/refbox.yaml
@@ -17,7 +17,7 @@ services:
     command: llsf-refbox ${REFBOX_ARGS}
     volumes:
       - ${REFBOX_CONFIG}:/etc/rcll-refbox/:z
-      - ~/rcll-get-started/logs/refbox:/logs:z
+      - ${REFBOX_LOGS_DIR}/refbox:/logs:z
 
   frontend:
     container_name: refbox-frontend

--- a/setup.sh
+++ b/setup.sh
@@ -6,6 +6,7 @@ if [ -z "$rcll_compose_files_dir" ]; then
     rcll_compose_files_dir="${rcll_get_started_dir}/compose_files"
 fi
 
+export REFBOX_LOGS_DIR=$rcll_get_started_dir/logs
 export REFBOX_FRONTEND_TAG=latest
 export REFBOX_TAG=latest
 export MONGODB_BACKEND_TAG=latest


### PR DESCRIPTION
The logs location for the refbox is currently hard coded it will be changed to: ```$rcll_get_started_dir/logs```